### PR TITLE
Add 'path' include

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,6 +27,7 @@ Depending on your environment, you need to use **different import paths**. Curre
 const MTProto = require('@mtproto/core');
 // or
 // const MTProto = require('@mtproto/core/envs/node');
+const path = require('path');
 ```
 
 ### Import for `browser` environment
@@ -73,6 +74,7 @@ If you use the Telegram API for flooding, spamming, faking subscriber and view c
 
 ```js title="example.js"
 const MTProto = require('@mtproto/core');
+const path = require('path');
 
 const api_id = YOU_API_ID;
 const api_hash = YOU_API_HASH;

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,6 @@ Depending on your environment, you need to use **different import paths**. Curre
 const MTProto = require('@mtproto/core');
 // or
 // const MTProto = require('@mtproto/core/envs/node');
-const path = require('path');
 ```
 
 ### Import for `browser` environment
@@ -73,8 +72,8 @@ If you use the Telegram API for flooding, spamming, faking subscriber and view c
 ### Create simple file
 
 ```js title="example.js"
-const MTProto = require('@mtproto/core');
 const path = require('path');
+const MTProto = require('@mtproto/core');
 
 const api_id = YOU_API_ID;
 const api_hash = YOU_API_HASH;


### PR DESCRIPTION
The code from the example requires the Node package 'path' to be included. Without it the previous example.js file didn't work.